### PR TITLE
fix warning

### DIFF
--- a/includes/class-wp-otp-user-meta.php
+++ b/includes/class-wp-otp-user-meta.php
@@ -54,7 +54,7 @@ class Wp_Otp_User_Meta {
 	 * @since 0.1.0
 	 * @var array
 	 */
-	private static $user_meta;
+	private static $user_meta = array();
 
 	/**
 	 * User ID of the user whose meta data is managed.


### PR DESCRIPTION
The following warning is displayed:
Warning: count(): Parameter must be an array or an object that implements Countable in /var/www/wordpress/wp-content/plugins/wp-otp/includes/class-wp-otp-user-meta.php on line 104

I checked on WordPress 4.9.6 and php 7.2.6.